### PR TITLE
feat: padRight utility for padding strings

### DIFF
--- a/docs/pages/api.md
+++ b/docs/pages/api.md
@@ -17,6 +17,7 @@
 - [includes](/packages/includes)
 - [isString](/packages/isString)
 - [isUpperCase](/packages/isUpperCase)
+- [padRight](/packages/padRight)
 - [repeat](/packages/repeat)
 - [startsWith](/packages/startsWith)
 - [toCamelCase](/packages/toCamelCase)

--- a/packages/padRight/README.md
+++ b/packages/padRight/README.md
@@ -1,0 +1,13 @@
+# `@plexis/padRight`
+
+Pads the string with another string until the resulting string reaches the given length.
+The padding is applied in the end of the string.
+
+## Usage
+
+```
+const padRight = require('@plexis/pad-right');
+
+padRight('Foo Bar', 10, '*'); // Foo Bar***
+padRight('Foo Bar', 10, '123'); // Foo Bar123
+```

--- a/packages/padRight/README.md
+++ b/packages/padRight/README.md
@@ -8,6 +8,6 @@ The padding is applied in the end of the string.
 ```
 const padRight = require('@plexis/pad-right');
 
-padRight('Foo Bar', 10, '*'); // Foo Bar***
-padRight('Foo Bar', 10, '123'); // Foo Bar123
+padRight('Foo Bar', 10, '*'); // 'Foo Bar***'
+padRight('Foo Bar', 10, '123'); // 'Foo Bar123'
 ```

--- a/packages/padRight/package.json
+++ b/packages/padRight/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@plexis/pad-right",
+  "version": "0.0.22",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "files": ["dist", "src"],
+  "license": "MIT",
+  "keywords": [
+    "utility",
+    "string",
+    "parse",
+    "format",
+    "validate"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/plexis-js/plexis.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/padRight/src/index.js
+++ b/packages/padRight/src/index.js
@@ -1,3 +1,16 @@
+/**
+ * @description Returns a string padded with a delimiter string, applied in the end of the string.
+ * @param {String} string
+ * @param {Number} padLength
+ * @param {String} padDelimiter
+ * @example
+ * padRight('Foo Bar', 1); // => 'Foo Bar'
+ * padRight('Foo Bar', 7); // => 'Foo Bar'
+ * padRight('Foo Bar', 8) // => 'Foo Bar '
+ * padRight('Foo Bar', 10, '*' // => 'Foo Bar***'
+ * padRight('Foo Bar', 9, '123') // => 'Foo Bar12'
+ */
+
 const padRight = (string, padLength, padDelimiter = ' ') => {
   const padLengthDiff = padLength - string.length;
   if (padLengthDiff <= 0) {

--- a/packages/padRight/src/index.js
+++ b/packages/padRight/src/index.js
@@ -1,0 +1,22 @@
+const padRight = (string, padLength, padDelimiter = ' ') => {
+  const padLengthDiff = padLength - string.length;
+  if (padLengthDiff <= 0) {
+    return string;
+  }
+
+  const padDelimeterTimes = Math.ceil(padLengthDiff / padDelimiter.length);
+
+  const padDelimeterArray = [];
+  for (let i = 0; i < padDelimeterTimes; i++) {
+    const nextPadDelimeterLengthDiff = (i + 1) * padDelimiter.length - padLengthDiff;
+    const currentPadDelimiter =
+      nextPadDelimeterLengthDiff > 0
+        ? padDelimiter.slice(0, padDelimiter.length - nextPadDelimeterLengthDiff)
+        : padDelimiter;
+    padDelimeterArray.push(currentPadDelimiter);
+  }
+
+  return `${string}${padDelimeterArray.join('')}`;
+};
+
+export default padRight;

--- a/packages/padRight/test/index.test.js
+++ b/packages/padRight/test/index.test.js
@@ -1,0 +1,36 @@
+import padRight from '../src';
+
+describe('padRight', () => {
+  it('should return provided string when pad length is less or equal to the string length', () => {
+    expect(padRight('Foo Bar', 1)).toEqual('Foo Bar');
+    expect(padRight('Foo Bar', 7)).toEqual('Foo Bar');
+  });
+
+  it('should return right padded string with one default delimiter', () => {
+    expect(padRight('Foo Bar', 8)).toEqual('Foo Bar ');
+  });
+
+  it('should return right padded string with *', () => {
+    expect(padRight('Foo Bar', 8, '*')).toEqual('Foo Bar*');
+  });
+
+  it('should return right padded string with ***', () => {
+    expect(padRight('Foo Bar', 10, '*')).toEqual('Foo Bar***');
+  });
+
+  it('should return right padded string with 123', () => {
+    expect(padRight('Foo Bar', 10, '123')).toEqual('Foo Bar123');
+  });
+
+  it('should return right padded string with 12', () => {
+    expect(padRight('Foo Bar', 9, '123')).toEqual('Foo Bar12');
+  });
+
+  it('should return right padded string with 1231', () => {
+    expect(padRight('Foo Bar', 11, '123')).toEqual('Foo Bar1231');
+  });
+
+  it('should return right padded string with 12312', () => {
+    expect(padRight('Foo Bar', 12, '123')).toEqual('Foo Bar12312');
+  });
+});


### PR DESCRIPTION
Adding a padRight utility function for padding the string with another string, with padding applied in the end of the string.

Closes: https://github.com/plexis-js/plexis/issues/114